### PR TITLE
Evaluate presentation context errors introduced with iOS 13

### DIFF
--- a/Auth0/SafariAuthenticationCallback.swift
+++ b/Auth0/SafariAuthenticationCallback.swift
@@ -70,8 +70,28 @@ class SafariAuthenticationSessionCallback: NSObject, AuthTransaction {
         guard error == nil, url != nil else {
             let authError = error ?? WebAuthError.unknownError
 
-            if #available(iOS 12.0, *), case ASWebAuthenticationSessionError.canceledLogin = authError {
-                self.callback(.failure(error: WebAuthError.userCancelled))
+            if #available(iOS 13.0, *) {
+                switch authError {
+                case ASWebAuthenticationSessionError.canceledLogin:
+                    self.callback(.failure(error: WebAuthError.userCancelled))
+
+                case ASWebAuthenticationSessionError.presentationContextInvalid:
+                    self.callback(.failure(error: WebAuthError.presentationContextInvalid))
+
+                case ASWebAuthenticationSessionError.presentationContextNotProvided:
+                    self.callback(.failure(error: WebAuthError.presentationContextNotProvided))
+
+                default:
+                    self.callback(.failure(error: authError))
+                }
+            } else if #available(iOS 12.0, *) {
+                switch authError {
+                case ASWebAuthenticationSessionError.canceledLogin:
+                    self.callback(.failure(error: WebAuthError.userCancelled))
+
+                default:
+                    self.callback(.failure(error: authError))
+                }
             } else if case SFAuthenticationError.canceledLogin = authError {
                 self.callback(.failure(error: WebAuthError.userCancelled))
             } else {

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -44,6 +44,8 @@ public enum WebAuthError: CustomNSError {
     case missingResponseParam(String)
     case invalidIdTokenNonce
     case missingAccessToken
+    case presentationContextInvalid
+    case presentationContextNotProvided
     case unknownError
 
     static let genericFoundationCode = 1

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -371,7 +371,7 @@ class WebAuthSpec: QuickSpec {
                     auth.clearSession(federated: false) { outcome = $0 }
                     TransactionStore.shared.cancel(TransactionStore.shared.current!)
 
-                    guard case let .failure(error)? = outcome, case WebAuthError.cancelled = error else {
+                    guard case let .failure(error)? = outcome, case WebAuthError.cancelledByIncomingSession = error else {
                         return XCTFail("Unexpected result!")
                     }
 


### PR DESCRIPTION
### Changes

Maps two new error cases `ASWebAuthenticationSessionError.presentationContextInvalid` and `ASWebAuthenticationSessionError.presentationContextNotProvided` introduced in iOS 13 to `WebAuthError.presentationContextInvalid` and `WebAuthError.presentationContextNotProvided` respectively. The goal is to expose the new error cases to the public API via `WebAuthError`.

- Two new cases added to `WebAuthError`:  `.presentationContextInvalid` and `.presentationContextNotProvided`

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not